### PR TITLE
Add maxit argument to copykat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 inst/doc
 .Rproj.user
+*.Rproj
+.Rbuildignore
+copykat.Rproj

--- a/R/baseline.GMM.R
+++ b/R/baseline.GMM.R
@@ -12,7 +12,7 @@
 #'
 #' test.gmm.cells <- test.bnc$preN
 #' @export
-baseline.GMM <- function(CNA.mat, max.normal=5, mu.cut=0.05, Nfraq.cut=0.99, RE.before=basa, n.cores=1){
+baseline.GMM <- function(CNA.mat, max.normal=5, mu.cut=0.05, Nfraq.cut=0.99, RE.before=basa, n.cores=1,maxit=10000){
 
      N.normal <-NULL
      for(m in 1:ncol(CNA.mat)){
@@ -20,7 +20,7 @@ baseline.GMM <- function(CNA.mat, max.normal=5, mu.cut=0.05, Nfraq.cut=0.99, RE.
       print(paste("cell: ", m, sep=""))
       sam <- CNA.mat[, m]
       sg <- max(c(0.05, 0.5*sd(sam)));
-      GM3 <- mixtools::normalmixEM(sam, lambda = rep(1,3)/3, mu = c(-0.2, 0, 0.2),sigma = sg,arbvar=FALSE,ECM=FALSE,maxit=500);#maxrestarts=10; arbmean=TRUE; arbvar=TRUE;epsilon=0.01
+      GM3 <- mixtools::normalmixEM(sam, lambda = rep(1,3)/3, mu = c(-0.2, 0, 0.2),sigma = sg,arbvar=FALSE,ECM=FALSE,maxit=maxit);#maxrestarts=10; arbmean=TRUE; arbvar=TRUE;epsilon=0.01
 
       ###decide normal or tumor
       s <- sum(abs(GM3$mu)<=mu.cut)

--- a/R/baseline.norm.cl.R
+++ b/R/baseline.norm.cl.R
@@ -14,7 +14,7 @@
 #' @export
 
 
-baseline.norm.cl <- function(norm.mat.smooth, min.cells=5, n.cores=n.cores){
+baseline.norm.cl <- function(norm.mat.smooth, min.cells=5, n.cores=n.cores,maxit=10000){
 
   d <- parallelDist::parDist(t(norm.mat.smooth), threads = n.cores) ##use smooth and segmented data to detect intra-normal cells
   km <- 6
@@ -35,7 +35,7 @@ baseline.norm.cl <- function(norm.mat.smooth, min.cells=5, n.cores=n.cores){
 
     data.c <- apply(norm.mat.smooth[, which(ct==i)],1, median)
     sx <- max(c(0.05, 0.5*sd(data.c)))
-    GM3 <- mixtools::normalmixEM(data.c, lambda = rep(1,3)/3, mu = c(-0.2, 0, 0.2), sigma = sx,arbvar=FALSE,ECM=FALSE,maxit=5000)
+    GM3 <- mixtools::normalmixEM(data.c, lambda = rep(1,3)/3, mu = c(-0.2, 0, 0.2), sigma = sx,arbvar=FALSE,ECM=FALSE,maxit=maxit)
     SDM <- c(SDM, GM3$sigma[1])
     SSD <- c(SSD, sd(data.c))
        i <- i+1

--- a/R/copykat.R
+++ b/R/copykat.R
@@ -16,6 +16,8 @@
 #' @param plot.genes TRUE or FALSE, output heatmap of CNVs with genename labels
 #' @param genome hg20 or mm10, current version only work for human or mouse genes
 #' @param min.gene.per.cell, default 200
+#' @param maxit, default 10000
+
 #' @return 1) aneuploid/diploid prediction results; 2) CNA results in 220KB windows; 3) heatmap; 4) hclustering object.
 #'
 #' @examples
@@ -27,7 +29,7 @@
 ###
 
 
-copykat <- function(rawmat=rawdata, id.type="S", cell.line="no", ngene.chr=5,min.gene.per.cell=200, LOW.DR=0.05, UP.DR=0.1, win.size=25, norm.cell.names="", KS.cut=0.1, sam.name="", distance="euclidean", output.seg="FALSE", plot.genes="TRUE", genome="hg20", n.cores=1){
+copykat <- function(rawmat=rawdata, id.type="S", cell.line="no", ngene.chr=5,min.gene.per.cell=200, LOW.DR=0.05, UP.DR=0.1, win.size=25, norm.cell.names="", KS.cut=0.1, sam.name="", distance="euclidean", output.seg="FALSE", plot.genes="TRUE", genome="hg20", n.cores=1,maxit=10000){
 
 start_time <- Sys.time()
   set.seed(1234)
@@ -162,14 +164,14 @@ start_time <- Sys.time()
       	norm.mat.relat <- norm.mat.smooth-basel
 
         }else {
-         basa <- baseline.norm.cl(norm.mat.smooth=norm.mat.smooth, min.cells=5, n.cores=n.cores)
+         basa <- baseline.norm.cl(norm.mat.smooth=norm.mat.smooth, min.cells=5, n.cores=n.cores,maxit=maxit)
           basel <- basa$basel
           WNS <- basa$WNS
           preN <- basa$preN
           CL <- basa$cl
           if (WNS =="unclassified.prediction"){
 
-                    basa <- baseline.GMM(CNA.mat=norm.mat.smooth, max.normal=5, mu.cut=0.05, Nfraq.cut=0.99,RE.before=basa,n.cores=n.cores)
+                    basa <- baseline.GMM(CNA.mat=norm.mat.smooth, max.normal=5, mu.cut=0.05, Nfraq.cut=0.99,RE.before=basa,n.cores=n.cores,maxit=maxit)
                     basel <-basa$basel
                     WNS <- basa$WNS
 

--- a/copykat.Rproj
+++ b/copykat.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: ed3b2526-9893-4402-bf2e-e53c5a678c5d
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
maxit argument will be passed into baseline.norm.cl() and baseline.GMM() to avoid not convergent issues.